### PR TITLE
LsfGenericIterator: point to first message if start index is 0.

### DIFF
--- a/src/pt/lsts/imc/lsf/LsfGenericIterator.java
+++ b/src/pt/lsts/imc/lsf/LsfGenericIterator.java
@@ -48,7 +48,10 @@ public class LsfGenericIterator implements Iterator<IMCMessage>, Iterable<IMCMes
         this.index = index;
         this.msgType = index.getDefinitions().getMessageId(msgType);
         this.timestepSeconds = timestepMillis / 1000.0;
-        this.nextIndex = index.getNextMessageOfType(msgType, startIndex);
+        if (startIndex == 0)
+            this.nextIndex = index.getFirstMessageOfType(msgType);
+        else
+            this.nextIndex = index.getNextMessageOfType(msgType, startIndex);
         divideById = index.fieldIdOf(nextIndex) != -1;        
     }
     


### PR DESCRIPTION
Shouldn't the iterator point to the first message if start index is 0 instead of fetching the next one ?